### PR TITLE
Show how httpOnly cookies are still broken

### DIFF
--- a/config/initializers/allow_reading_session_on_js_side.rb
+++ b/config/initializers/allow_reading_session_on_js_side.rb
@@ -1,6 +1,0 @@
-Rails.application.config.session_store(
-  :cookie_store,
-  key: '_cypress_cookie_issue_reproduction_session',
-  # We want to be able to read the server-set cookies on JS side
-  httponly: false
-)

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -4,23 +4,9 @@ describe('issue https://github.com/cypress-io/cypress/issues/25174 reproduction'
     cy.get('#do-xhr-request').click()
     cy.contains('A cookie has been set').should('be.visible')
 
-    cy.get('#client-cookies-json').invoke('text').should(text => {
-      const parsedText = JSON.parse(text)
-      // There should only be one cookie here
-      expect(parsedText).to.have.length(1)
-    });
-
-    // Debug with cy.getAllCookies if that exists (Cypress v12.1.0+ only)
-    if (cy.getAllCookies) {
-      cy.getAllCookies().then(cookies => cy.log("Cookie domains are:", cookies.map(c => c.domain)))
-    }
-
-    cy.get('#client-cookies-json-timeout').invoke('text').should(text => {
-      const parsedText = JSON.parse(text)
-      // This is the strange thing!
-      // There should only be one cookie here, too
-      expect(parsedText).to.have.length(1)
-    });
+    // This is the strange thing! There should only be one cookie set
+    cy.getAllCookies().then(cookies => cy.log("Cookie domains are:", cookies.map(c => c.domain)))
+    cy.getAllCookies().should('have.length', 1)
   })
 
   it('creates two cookies with a fetch request', () => {
@@ -28,22 +14,8 @@ describe('issue https://github.com/cypress-io/cypress/issues/25174 reproduction'
     cy.get('#do-fetch-request').click()
     cy.contains('A cookie has been set').should('be.visible')
 
-    cy.get('#client-cookies-json').invoke('text').should(text => {
-      const parsedText = JSON.parse(text)
-      // There should only be one cookie here
-      expect(parsedText).to.have.length(1)
-    });
-
-    // Debug with cy.getAllCookies if that exists (Cypress v12.1.0+ only)
-    if (cy.getAllCookies) {
-      cy.getAllCookies().then(cookies => cy.log("Cookie domains are:", cookies.map(c => c.domain)))
-    }
-
-    cy.get('#client-cookies-json-timeout').invoke('text').should(text => {
-      const parsedText = JSON.parse(text)
-      // This is the strange thing!
-      // There should only be one cookie here, too
-      expect(parsedText).to.have.length(1)
-    });
+    // This is the strange thing! There should only be one cookie set
+    cy.getAllCookies().then(cookies => cy.log("Cookie domains are:", cookies.map(c => c.domain)))
+    cy.getAllCookies().should('have.length', 1)
   })
 })


### PR DESCRIPTION
<img width="1280" alt="cypress-cookie-issue-reproduction" src="https://user-images.githubusercontent.com/482561/210792480-42bdb109-9990-4143-b095-64f18153d6b5.png">

<img width="1228" alt="CypressCookieIssueReproduction" src="https://user-images.githubusercontent.com/482561/210792892-7956f1f3-8c32-4cd6-80dc-5b265a7d15a9.png">

